### PR TITLE
Create order and calculate commissions

### DIFF
--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -41,4 +41,6 @@ class Disbursement < ApplicationRecord
   validates :merchant, :reference, :status, :frequency, :reference_date, presence: true
   validates :calculated_at, presence: true, if: -> { calculated? }
   validates_uniqueness_of :reference
+
+  scope :pending_or_processing, -> { where(status: [::Enum::DisbursementStatuses::PENDING, ::Enum::DisbursementStatuses::PROCESSING]) }
 end

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -43,4 +43,16 @@ class Disbursement < ApplicationRecord
   validates_uniqueness_of :reference
 
   scope :pending_or_processing, -> { where(status: [::Enum::DisbursementStatuses::PENDING, ::Enum::DisbursementStatuses::PROCESSING]) }
+
+  def update_totals_from!(commission)
+    raise "Disbursement already calculated" if calculated?
+
+    commissions << commission
+    self.total_commission_fee += commission.fee_value
+    self.total_amount += commission.order_amount
+    self.disbursed_amount += commission.disbursed_amount
+    self.status = ::Enum::DisbursementStatuses::PROCESSING
+
+    save!
+  end
 end

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -1,0 +1,22 @@
+class Fee
+  attr_reader :percentage, :order_amount
+
+  def initialize(percentage:, from_amount:)
+    @percentage = percentage
+    @order_amount = from_amount
+  end
+
+  def value
+    percentage * order_amount
+  end
+
+  def disbursed_amount
+    order_amount - value
+  end
+
+  def ==(other)
+    percentage == other.percentage &&
+      value == other.value &&
+      order_amount == other.order_amount
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -4,5 +4,5 @@ class Order < ApplicationRecord
 
   belongs_to :merchant
 
-  validates_uniqueness_of :reference
+  validates :reference, presence: true, uniqueness: true
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,6 +3,7 @@ class Order < ApplicationRecord
   monetize :amount_cents
 
   belongs_to :merchant
+  has_many :commissions
 
   validates :reference, presence: true, uniqueness: true
 end

--- a/app/use_cases/calculate_commission.rb
+++ b/app/use_cases/calculate_commission.rb
@@ -1,0 +1,24 @@
+class CalculateCommission
+  def call(order:)
+    ActiveRecord::Base.transaction do
+      disbursement = find_or_create_disbursement!(order)
+      fee = calculate_fee(order)
+      commission = create_commission!(order, disbursement, fee)
+      disbursement.update_totals_from!(commission)
+    end
+  end
+
+  private
+
+  def find_or_create_disbursement!(order)
+    ::FindOrCreateDisbursement.new.call(order)
+  end
+
+  def calculate_fee(order)
+    ::CalculateFee.new.call(order)
+  end
+
+  def create_commission!(order, disbursement, fee)
+    ::CreateCommission.new.call(order:, disbursement:, fee:)
+  end
+end

--- a/app/use_cases/calculate_fee.rb
+++ b/app/use_cases/calculate_fee.rb
@@ -1,0 +1,11 @@
+class CalculateFee
+  def call(order)
+    if order.amount < Money.from_amount(50)
+      1 / 100.0 # 1%
+    elsif order.amount < Money.from_amount(300)
+      0.95 / 100.0 # 0.95%
+    else
+      0.85 / 100.0 # 0.85%
+    end
+  end
+end

--- a/app/use_cases/calculate_fee.rb
+++ b/app/use_cases/calculate_fee.rb
@@ -1,11 +1,12 @@
 class CalculateFee
   def call(order)
+    percentage = 0.85 / 100.0 # 0.85%
     if order.amount < Money.from_amount(50)
-      1 / 100.0 # 1%
+      percentage = 1 / 100.0 # 1%
     elsif order.amount < Money.from_amount(300)
-      0.95 / 100.0 # 0.95%
-    else
-      0.85 / 100.0 # 0.85%
+      percentage = 0.95 / 100 # 0.95%
     end
+
+    Fee.new(percentage:, from_amount: order.amount)
   end
 end

--- a/app/use_cases/create_commission.rb
+++ b/app/use_cases/create_commission.rb
@@ -1,0 +1,11 @@
+class CreateCommission
+  def call(order:, disbursement:, fee:)
+    ::Commission.create!(
+      order:, disbursement:,
+      order_amount: fee.order_amount,
+      fee_percentage: fee.percentage,
+      fee_value: fee.value,
+      disbursed_amount: fee.disbursed_amount
+    )
+  end
+end

--- a/app/use_cases/create_order.rb
+++ b/app/use_cases/create_order.rb
@@ -1,0 +1,24 @@
+class CreateOrder
+  def call(reference:, merchant_reference:, amount:, created_at: Time.zone.now)
+    merchant = find_merchant(merchant_reference)
+    order = create_order(reference:, merchant:, amount:, created_at:)
+    calculate_commission(order)
+
+    order
+  end
+
+  private
+
+  def find_merchant(reference)
+    Merchant.find_by(reference: reference).tap do |merchant|
+      raise "Merchant not found" unless merchant
+    end
+  end
+
+  def create_order(reference:, merchant:, amount:, created_at:)
+    Order.create!(reference:, merchant:, amount:, created_at:)
+  end
+
+  def calculate_commission(order)
+  end
+end

--- a/app/use_cases/create_order.rb
+++ b/app/use_cases/create_order.rb
@@ -20,5 +20,6 @@ class CreateOrder
   end
 
   def calculate_commission(order)
+    ::CalculateCommission.new.call(order:)
   end
 end

--- a/app/use_cases/find_or_create_disbursement.rb
+++ b/app/use_cases/find_or_create_disbursement.rb
@@ -1,0 +1,51 @@
+class FindOrCreateDisbursement
+  def call(order)
+    find_disbursement(order) || create_disbursement(order)
+  end
+
+  private
+
+  def find_disbursement(order)
+    if order.merchant.daily?
+      Disbursement.find_by(merchant: order.merchant, reference_date: order.created_at.to_date)
+    else
+      reference_date = reference_date_from(order)
+
+      Disbursement.find_by(merchant: order.merchant, reference_date:)
+    end
+  end
+
+  def create_disbursement(order)
+    Disbursement.create!(
+      reference: SecureRandom.hex(10),
+      reference_date: reference_date_from(order),
+      frequency: order.merchant.disbursement_frequency,
+      merchant: order.merchant
+    )
+  end
+
+  def reference_date_from(order)
+    created_at = order.created_at.to_date
+
+    return created_at if order.merchant.daily?
+
+    weekday = order.merchant.live_on.wday
+    if created_at.wday == weekday
+      created_at
+    else
+      created_at.prev_occurring(number_to_weekday(weekday))
+    end
+  end
+
+  def number_to_weekday(number)
+    {
+      1 => :monday,
+      2 => :tuesday,
+      3 => :wednesday,
+      4 => :thursday,
+      5 => :friday,
+      6 => :saturday,
+      7 => :sunday
+    }.fetch(number)
+  end
+end

--- a/app/use_cases/find_or_create_disbursement.rb
+++ b/app/use_cases/find_or_create_disbursement.rb
@@ -6,13 +6,10 @@ class FindOrCreateDisbursement
   private
 
   def find_disbursement(order)
-    if order.merchant.daily?
-      Disbursement.find_by(merchant: order.merchant, reference_date: order.created_at.to_date)
-    else
-      reference_date = reference_date_from(order)
+    reference_date = order.created_at.to_date
+    reference_date = reference_date_from(order) if order.merchant.weekly?
 
-      Disbursement.find_by(merchant: order.merchant, reference_date:)
-    end
+    Disbursement.pending_or_processing.find_by(merchant: order.merchant, reference_date:)
   end
 
   def create_disbursement(order)

--- a/spec/factories/disbursement.rb
+++ b/spec/factories/disbursement.rb
@@ -22,6 +22,19 @@ FactoryBot.define do
       frequency { ::Enum::DisbursementFrequencies::WEEKLY }
     end
 
+    trait :pending do
+      status { ::Enum::DisbursementStatuses::PENDING }
+    end
+
+    trait :processing do
+      status { ::Enum::DisbursementStatuses::PROCESSING }
+    end
+
+    trait :calculated do
+      status { ::Enum::DisbursementStatuses::CALCULATED }
+      calculated_at { Time.current }
+    end
+
     trait :with_commissions do
       transient do
         commissions_count { 5 }

--- a/spec/models/disbursement_spec.rb
+++ b/spec/models/disbursement_spec.rb
@@ -10,4 +10,37 @@ RSpec.describe Disbursement do
       expect(Disbursement.pending_or_processing).to contain_exactly(pending, processing)
     end
   end
+
+  context "when updating totals from commission" do
+    it "raises error if disbursement is already calculated" do
+      disbursement = create(:disbursement, :calculated)
+      commission = create(:commission)
+
+      expect {
+        disbursement.update_totals_from!(commission)
+      }.to raise_error("Disbursement already calculated")
+    end
+
+    it "adds commission to disbursement and updates totals" do
+      total_commission_fee = Money.from_amount(30)
+      total_amount = Money.from_amount(200)
+      disbursed_amount = Money.from_amount(170)
+      disbursement = create(:disbursement, :pending,
+        total_commission_fee:, total_amount:, disbursed_amount:)
+
+      fee_value = Money.from_amount(50)
+      order_amount = Money.from_amount(400)
+      commission_disbursed_amount = Money.from_amount(350)
+      commission = create(:commission, disbursement:,
+        fee_value:, order_amount:, disbursed_amount: commission_disbursed_amount)
+
+      disbursement.update_totals_from!(commission)
+
+      expect(disbursement).to be_processing
+      expect(disbursement.commissions).to contain_exactly(commission)
+      expect(disbursement.total_commission_fee).to eq(total_commission_fee + fee_value)
+      expect(disbursement.total_amount).to eq(total_amount + order_amount)
+      expect(disbursement.disbursed_amount).to eq(disbursed_amount + commission_disbursed_amount)
+    end
+  end
 end

--- a/spec/models/disbursement_spec.rb
+++ b/spec/models/disbursement_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe Disbursement do
+  context "when retrieving pending or processing disbursements" do
+    it "returns disbursements with status pending or processing" do
+      pending = create(:disbursement, :pending)
+      processing = create(:disbursement, :processing)
+      _calculated = create(:disbursement, :calculated)
+
+      expect(Disbursement.pending_or_processing).to contain_exactly(pending, processing)
+    end
+  end
+end

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe ::Fee do
+  it "initializes with percentage and amount" do
+    fee = described_class.new(percentage: 30 / 100.0, from_amount: Money.from_amount(100))
+
+    expect(fee.percentage).to eq 0.3
+    expect(fee.order_amount).to eq Money.from_amount(100)
+  end
+
+  it "returns the value of the fee" do
+    fee = described_class.new(percentage: 30 / 100.0, from_amount: Money.from_amount(100))
+
+    expect(fee.value).to eq Money.from_amount(30)
+  end
+
+  it "returns the disbursed amount" do
+    fee = described_class.new(percentage: 30 / 100.0, from_amount: Money.from_amount(100))
+
+    expect(fee.disbursed_amount).to eq Money.from_amount(70)
+  end
+
+  it "it equal to other fee by their attributes" do
+    fee1 = described_class.new(percentage: 0.85 / 100.0, from_amount: Money.from_amount(100))
+    fee2 = described_class.new(percentage: 0.85 / 100.0, from_amount: Money.from_amount(100))
+
+    expect(fee1).to eq fee2
+  end
+end

--- a/spec/use_cases/calculate_commission_spec.rb
+++ b/spec/use_cases/calculate_commission_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+RSpec.describe ::CalculateCommission do
+  context "when disbursement already exists" do
+    it "creates commission for existing disbursement" do
+      merchant = create(:merchant, :daily)
+      created_at = Date.parse("2024-02-02")
+      order = create(:order, merchant:, created_at:)
+      disbursement = create(:disbursement, :pending,
+        merchant:, commissions: [], reference_date: order.created_at.to_date)
+
+      described_class.new.call(order:)
+
+      disbursement.reload
+      commissions = disbursement.commissions
+      expect(disbursement).to be_processing
+      expect(commissions.count).to eq(1)
+      expect(commissions.first.order).to eq(order)
+    end
+
+    it "updates disbursement totals with commission values" do
+      merchant = create(:merchant, :daily)
+      created_at = Date.parse("2024-02-02")
+      order = create(:order, merchant:, created_at:)
+      disbursement = create(:disbursement, :pending,
+        merchant:, commissions: [], reference_date: order.created_at.to_date,
+        total_commission_fee: 0, total_amount: 0, disbursed_amount: 0)
+
+      described_class.new.call(order:)
+
+      disbursement.reload
+      commission = disbursement.commissions.first
+      expect(disbursement).to be_processing
+      expect(disbursement.total_commission_fee).to eq(commission.fee_value)
+      expect(disbursement.total_amount).to eq(order.amount)
+      expect(disbursement.disbursed_amount).to eq(commission.disbursed_amount)
+    end
+
+    context "when creating commission fails" do
+      it "does not create commission and dont update disbursement" do
+        merchant = create(:merchant, :daily)
+        created_at = Date.parse("2024-02-02")
+        order = create(:order, merchant:, created_at:)
+        disbursement = create(:disbursement, :pending,
+          merchant:, commissions: [], reference_date: order.created_at.to_date,
+          total_commission_fee: 0, total_amount: 0, disbursed_amount: 0)
+
+        allow(Commission).to receive(:create!).and_raise("some error")
+
+        expect {
+          described_class.new.call(order:)
+        }.to raise_error("some error")
+
+        disbursement.reload
+        expect(disbursement).to be_pending
+        expect(disbursement.commissions).to be_empty
+        expect(disbursement.total_commission_fee).to eq(0)
+        expect(disbursement.total_amount).to eq(0)
+        expect(disbursement.disbursed_amount).to eq(0)
+      end
+    end
+  end
+
+  context "when disbursement does not exist" do
+    it "creates commission for new disbursement" do
+      merchant = create(:merchant, :daily)
+      created_at = Date.parse("2024-02-02")
+      order = create(:order, merchant:, created_at:)
+
+      described_class.new.call(order:)
+
+      order.reload
+      commissions = order.commissions
+      disbursement = Disbursement.last
+      expect(disbursement).to be_processing
+      expect(commissions.count).to eq(1)
+      expect(disbursement.commissions).to eq(commissions)
+    end
+
+    it "updates new disbursement with totals from commission values" do
+      merchant = create(:merchant, :daily)
+      created_at = Date.parse("2024-02-02")
+      order = create(:order, merchant:, created_at:)
+
+      described_class.new.call(order:)
+
+      order.reload
+      commission = order.commissions.first
+      disbursement = commission.disbursement
+      expect(disbursement).to be_processing
+      expect(disbursement.total_commission_fee).to eq(commission.fee_value)
+      expect(disbursement.total_amount).to eq(order.amount)
+      expect(disbursement.disbursed_amount).to eq(commission.disbursed_amount)
+    end
+
+    context "when creating disbursement fails" do
+      it "does not create commission" do
+        merchant = create(:merchant, :daily)
+        created_at = Date.parse("2024-02-02")
+        order = create(:order, merchant:, created_at:)
+
+        allow(Disbursement).to receive(:create!).and_raise("some error")
+
+        expect {
+          described_class.new.call(order:)
+        }.to raise_error("some error")
+
+        order.reload
+        expect(order.commissions).to be_empty
+        expect(Disbursement.count).to eq(0)
+      end
+    end
+
+    context "when creating commission fails" do
+      it "does not create disbursement nor commission" do
+        merchant = create(:merchant, :daily)
+        created_at = Date.parse("2024-02-02")
+        order = create(:order, merchant:, created_at:)
+
+        allow(Commission).to receive(:create!).and_raise("some error")
+
+        expect {
+          described_class.new.call(order:)
+        }.to raise_error("some error")
+
+        expect(Disbursement.count).to eq(0)
+        expect(Commission.count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/use_cases/calculate_fee_spec.rb
+++ b/spec/use_cases/calculate_fee_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe ::CalculateFee do
+  it "returns 1% when amount is less than 50" do
+    order = build(:order, amount: Money.from_amount(49))
+
+    expect(described_class.new.call(order)).to eq 1 / 100.0
+  end
+
+  it "returns 0.95% when amount is between 50 and 300" do
+    order1 = build(:order, amount: Money.from_amount(50))
+    order2 = build(:order, amount: Money.from_amount(299))
+
+    expect(described_class.new.call(order1)).to eq 0.95 / 100.0
+    expect(described_class.new.call(order2)).to eq 0.95 / 100.0
+  end
+
+  it "returns 0.85% when amount is greater than or equal to 300" do
+    order1 = build(:order, amount: Money.from_amount(300))
+    order2 = build(:order, amount: Money.from_amount(500))
+
+    expect(described_class.new.call(order1)).to eq 0.85 / 100.0
+    expect(described_class.new.call(order2)).to eq 0.85 / 100.0
+  end
+end

--- a/spec/use_cases/calculate_fee_spec.rb
+++ b/spec/use_cases/calculate_fee_spec.rb
@@ -4,22 +4,55 @@ RSpec.describe ::CalculateFee do
   it "returns 1% when amount is less than 50" do
     order = build(:order, amount: Money.from_amount(49))
 
-    expect(described_class.new.call(order)).to eq 1 / 100.0
+    fee = described_class.new.call(order)
+
+    expect(fee.percentage).to eq 1 / 100.0
+    expect(fee.order_amount).to eq order.amount
+    expect(fee.value).to eq(order.amount * 1 / 100.0)
+    expect(fee.disbursed_amount).to eq(order.amount - fee.value)
+  end
+
+  it "returns 0.95% when amount is equal to 50" do
+    order = build(:order, amount: Money.from_amount(50))
+
+    fee = described_class.new.call(order)
+
+    expect(fee.percentage).to eq 0.95 / 100.0
+    expect(fee.order_amount).to eq order.amount
+    expect(fee.value).to eq(order.amount * 0.95 / 100.0)
+    expect(fee.disbursed_amount).to eq(order.amount - fee.value)
   end
 
   it "returns 0.95% when amount is between 50 and 300" do
-    order1 = build(:order, amount: Money.from_amount(50))
-    order2 = build(:order, amount: Money.from_amount(299))
+    order = build(:order, amount: Money.from_amount(299))
 
-    expect(described_class.new.call(order1)).to eq 0.95 / 100.0
-    expect(described_class.new.call(order2)).to eq 0.95 / 100.0
+    fee = described_class.new.call(order)
+
+    expect(fee.percentage).to eq 0.95 / 100.0
+    expect(fee.order_amount).to eq order.amount
+    expect(fee.value).to eq(order.amount * 0.95 / 100.0)
+    expect(fee.disbursed_amount).to eq(order.amount - fee.value)
   end
 
-  it "returns 0.85% when amount is greater than or equal to 300" do
-    order1 = build(:order, amount: Money.from_amount(300))
-    order2 = build(:order, amount: Money.from_amount(500))
+  it "returns 0.85% when amount is equal to 300" do
+    order = build(:order, amount: Money.from_amount(300))
 
-    expect(described_class.new.call(order1)).to eq 0.85 / 100.0
-    expect(described_class.new.call(order2)).to eq 0.85 / 100.0
+    fee = described_class.new.call(order)
+
+    expect(fee.percentage).to eq 0.85 / 100.0
+    expect(fee.order_amount).to eq order.amount
+    expect(fee.value).to eq(order.amount * 0.85 / 100.0)
+    expect(fee.disbursed_amount).to eq(order.amount - fee.value)
+  end
+
+  it "returns 0.85% when amount is greater than 300" do
+    order = build(:order, amount: Money.from_amount(301))
+
+    fee = described_class.new.call(order)
+
+    expect(fee.percentage).to eq 0.85 / 100.0
+    expect(fee.order_amount).to eq order.amount
+    expect(fee.value).to eq(order.amount * 0.85 / 100.0)
+    expect(fee.disbursed_amount).to eq(order.amount - fee.value)
   end
 end

--- a/spec/use_cases/create_commission_spec.rb
+++ b/spec/use_cases/create_commission_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe ::CreateCommission do
+  context "when any attribute is invalid" do
+    it "raises an error" do
+      fee = Fee.new(percentage: 30 / 100.0, from_amount: Money.from_amount(100))
+
+      expect {
+        described_class.new.call(
+          disbursement: nil, order: nil, fee:
+        )
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  context "when all attributes are valid" do
+    it "creates commission" do
+      disbursement = create(:disbursement)
+      order = create(:order)
+      fee = Fee.new(percentage: 30 / 100.0, from_amount: Money.from_amount(100))
+
+      commission = described_class.new.call(
+        disbursement:, order:, fee:
+      )
+
+      expect(commission).to be_persisted
+      expect(commission.order).to eq order
+      expect(commission.disbursement).to eq disbursement
+      expect(commission.order_amount).to eq order.amount
+      expect(commission.fee_percentage).to eq fee.percentage
+      expect(commission.fee_value).to eq fee.value
+      expect(commission.disbursed_amount).to eq fee.disbursed_amount
+    end
+  end
+end

--- a/spec/use_cases/create_order_spec.rb
+++ b/spec/use_cases/create_order_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe ::CreateOrder do
+  it "raises an error when merchant is not found" do
+    expect {
+      described_class.new.call(
+        reference: SecureRandom.hex(10),
+        merchant_reference: SecureRandom.hex(10),
+        amount: Money.from_amount(100)
+      )
+    }.to raise_error("Merchant not found")
+  end
+
+  it "raises an error when any attribute is invalid" do
+    merchant = create(:merchant)
+
+    expect {
+      described_class.new.call(
+        reference: nil,
+        merchant_reference: merchant.reference,
+        amount: nil
+      )
+    }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  context "when all attributes are valid" do
+    context "when created_at is not provided" do
+      it "creates order using current date as created_at" do
+        reference = "order-reference"
+        amount = Money.from_amount(100)
+        merchant = create(:merchant)
+
+        order = described_class.new.call(
+          reference:, amount:,
+          merchant_reference: merchant.reference
+        )
+
+        expect(order).to be_persisted
+        expect(order.reference).to eq reference
+        expect(order.amount).to eq amount
+        expect(order.merchant).to eq merchant
+        expect(order.created_at).to be_within(1.minute).of(Time.zone.now)
+      end
+    end
+
+    context "when created_at is provided" do
+      it "creates order using the provided created_at" do
+        reference = "order-reference"
+        amount = Money.from_amount(100)
+        merchant = create(:merchant)
+        created_at = "2024-02-02"
+
+        order = described_class.new.call(
+          reference:, amount:, created_at:,
+          merchant_reference: merchant.reference
+        )
+
+        expect(order).to be_persisted
+        expect(order.reference).to eq reference
+        expect(order.amount).to eq amount
+        expect(order.merchant).to eq merchant
+        expect(order.created_at).to eq Date.parse(created_at)
+      end
+    end
+  end
+end

--- a/spec/use_cases/create_order_spec.rb
+++ b/spec/use_cases/create_order_spec.rb
@@ -62,5 +62,18 @@ RSpec.describe ::CreateOrder do
         expect(order.created_at).to eq Date.parse(created_at)
       end
     end
+
+    it "calculates commission for the order" do
+      reference = "order-reference"
+      amount = Money.from_amount(100)
+      merchant = create(:merchant)
+
+      order = described_class.new.call(
+        reference:, amount:,
+        merchant_reference: merchant.reference
+      )
+
+      expect(order.commissions.count).to eq 1
+    end
   end
 end

--- a/spec/use_cases/find_or_create_disbursement_spec.rb
+++ b/spec/use_cases/find_or_create_disbursement_spec.rb
@@ -1,0 +1,147 @@
+require "rails_helper"
+
+RSpec.describe ::FindOrCreateDisbursement do
+  include ActiveSupport::Testing::TimeHelpers
+
+  context "when disbursement is found" do
+    context "when merchant disbursement frequency is daily" do
+      it "returns disbursement found on the order created_at date" do
+        merchant = create(:merchant, :daily)
+        created_at = Date.parse("2024-02-02")
+        order = create(:order, merchant:, created_at:)
+        disbursement = create(:disbursement, merchant:, reference_date: order.created_at.to_date)
+
+        found_disbursement = nil
+
+        expect {
+          found_disbursement = described_class.new.call(order)
+        }.not_to change(Disbursement, :count)
+
+        expect(found_disbursement).to eq disbursement
+      end
+    end
+
+    context "when merchant disbursement frequency is weekly" do
+      it "returns disbursement found on the latest day before order created at on the merchant's live_on weekday as reference date" do
+        # today = wednesday
+        travel_to Date.today.next_occurring(:wednesday)
+
+        live_on = Date.today - 4.weeks # wednesday
+        merchant = create(:merchant, :weekly, live_on:)
+
+        created_at = Date.today + 2.days # next friday
+        order = create(:order, merchant:, created_at:)
+        disbursement = create(:disbursement, merchant:, reference_date: Date.today) # wednesday
+
+        found_disbursement = nil
+
+        expect {
+          found_disbursement = described_class.new.call(order)
+        }.not_to change(Disbursement, :count)
+
+        expect(found_disbursement).to eq disbursement
+
+        travel_back
+      end
+
+      it "returns disbursement found on the order created_at date if merchant's live_on weekday is the same as order created_at" do
+        # today = wednesday
+        travel_to Date.today.next_occurring(:wednesday)
+
+        live_on = Date.today - 4.weeks # wednesday
+        merchant = create(:merchant, :weekly, live_on:)
+
+        created_at = Date.today + 1.week # next wednesday
+        order = create(:order, merchant:, created_at:)
+        disbursement = create(:disbursement, merchant:, reference_date: order.created_at.to_date)
+
+        found_disbursement = nil
+
+        expect {
+          found_disbursement = described_class.new.call(order)
+        }.not_to change(Disbursement, :count)
+
+        expect(found_disbursement).to eq disbursement
+
+        travel_back
+      end
+    end
+  end
+
+  context "when disbursement is not found" do
+    context "when merchant disbursement frequency is daily" do
+      it "creates disbursement with order created at as reference date" do
+        merchant = create(:merchant, :daily)
+        created_at = Date.parse("2024-02-02")
+        order = create(:order, merchant:, created_at:)
+
+        disbursement = nil
+
+        expect {
+          disbursement = described_class.new.call(order)
+        }.to change(Disbursement, :count).by(1)
+
+        expect(disbursement.reference).to be_present
+        expect(disbursement).to be_pending
+        expect(disbursement.frequency).to eq merchant.disbursement_frequency
+        expect(disbursement.reference_date).to eq created_at
+        expect(disbursement.calculated_at).to be_nil
+        expect(disbursement.merchant).to eq merchant
+      end
+    end
+
+    context "when merchant disbursement frequency is weekly" do
+      it "creates disbursement with latest day before order created at on the merchant's live_on weekday as reference date" do
+        # today = wednesday
+        travel_to Date.today.next_occurring(:wednesday)
+
+        live_on = Date.today - 4.weeks # wednesday
+        merchant = create(:merchant, :weekly, live_on:)
+
+        created_at = Date.today + 2.days # next friday
+        order = create(:order, merchant:, created_at:)
+
+        disbursement = nil
+
+        expect {
+          disbursement = described_class.new.call(order)
+        }.to change(Disbursement, :count).by(1)
+
+        expect(disbursement.reference).to be_present
+        expect(disbursement).to be_pending
+        expect(disbursement.frequency).to eq merchant.disbursement_frequency
+        expect(disbursement.reference_date).to eq Date.today # this wednesday
+        expect(disbursement.calculated_at).to be_nil
+        expect(disbursement.merchant).to eq merchant
+
+        travel_back
+      end
+
+      it "creates disbursement with order created at as reference date if merchant's live_on weekday is the same as order created_at" do
+        # today = wednesday
+        travel_to Date.today.next_occurring(:wednesday)
+
+        live_on = Date.today - 4.weeks # wednesday
+        merchant = create(:merchant, :weekly, live_on:)
+
+        created_at = Date.today + 1.week # next wednesday
+        order = create(:order, merchant:, created_at:)
+
+        disbursement = nil
+
+        expect {
+          disbursement = described_class.new.call(order)
+        }.to change(Disbursement, :count).by(1)
+
+        expect(disbursement.reference).to be_present
+        expect(disbursement).to be_pending
+        expect(disbursement.frequency).to eq merchant.disbursement_frequency
+        expect(disbursement.reference_date).to eq order.created_at.to_date
+        expect(disbursement.calculated_at).to be_nil
+        expect(disbursement.merchant).to eq merchant
+
+        travel_back
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add use cases necessary to create orders and their commissions, following this diagram:
<img width="607" alt="image" src="https://github.com/camilacampos/sequra-challenge/assets/2309096/cd94efd7-804e-4135-b0ac-091cb2765c83">

To calculate the commission values for the disbursements, one possibility was to run a process everyday going through all the orders that need to be disbursed that day and calculating its commission and disbursement. However, this could lead to a very slow process.

To avoid that, I decide to have a "kind of" event-oriented approach, where whenever a new order comes, its commission values are already calculated and saved.

To actually "close" a disbursement, a daily process still need to occur, but it will just change the disbursement status, without needing any calculations. (Next PRs)