### PR TITLE
Close disbursement calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ make lint-fix # run lint and automatically fix issues
 ## Challenge description
 
 Refer to [challenge_description.md](challenge_description.md)
+
+## Report
+
+| Year | Number of disbursements | Amount disbursed to merchants | Amount of order fees | Number of monthly fees charged (From minimum monthly fee) | Amount of monthly fee charged (From minimum monthly fee) |
+| --- | --- | --- | --- | --- | --- |
+| 2022 | 1548 | 39.173.739,73 € | 350.774,71 € | 1.548 | 212,01 € |
+| 2023 | 10352 | 188.363.118,18 € | 1.692.163,42 € | 10.352 | 1.757,16 € |
+

--- a/app/jobs/finish_disbursements_calculation_job.rb
+++ b/app/jobs/finish_disbursements_calculation_job.rb
@@ -1,0 +1,10 @@
+class FinishDisbursementsCalculationJob < ApplicationJob
+  def perform
+    disbursements = Disbursement.pending_or_processing
+      .where(reference_date: Date.today.beginning_of_day..Date.today.end_of_day)
+
+    disbursements.each do |disbursement|
+      FinishDisbursementCalculation.new.call(disbursement)
+    end
+  end
+end

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -44,6 +44,13 @@ class Disbursement < ApplicationRecord
 
   scope :pending_or_processing, -> { where(status: [::Enum::DisbursementStatuses::PENDING, ::Enum::DisbursementStatuses::PROCESSING]) }
 
+  scope :by_month, ->(month) { where(reference_date: month.beginning_of_month..month.end_of_month) }
+  scope :by_merchant, ->(merchant) { where(merchant: merchant) }
+
+  def first_of_the_month?
+    reference_date.day == 1
+  end
+
   def update_totals_from!(commission)
     raise "Disbursement already calculated" if calculated?
 

--- a/app/use_cases/finish_disbursement_calculation.rb
+++ b/app/use_cases/finish_disbursement_calculation.rb
@@ -1,0 +1,28 @@
+class FinishDisbursementCalculation
+  def call(disbursement)
+    disbursement.monthly_fee = calculate_monthly_fee(disbursement)
+    disbursement.status = Enum::DisbursementStatuses::CALCULATED
+    disbursement.calculated_at = Time.zone.now
+
+    disbursement.save!
+  end
+
+  private
+
+  def calculate_monthly_fee(disbursement)
+    return 0 unless disbursement.first_of_the_month?
+
+    merchant = disbursement.merchant
+
+    last_month_disbursements = Disbursement
+      .by_month(disbursement.reference_date.prev_month)
+      .by_merchant(merchant)
+      .calculated
+
+    last_month_commissions = Money.new(last_month_disbursements.sum(:total_commission_fee_cents))
+
+    return 0 if merchant.minimum_monthly_fee < last_month_commissions
+
+    disbursement.monthly_fee = merchant.minimum_monthly_fee - last_month_commissions
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,3 +5,9 @@
   - [default, 3]
   - [low, 2]
   - [very_low, 1]
+
+:scheduler:
+  :schedule:
+    finish_disbursements_calculation:
+      cron: "50 19 * * *" # Everyday 7:50 PM
+      class: FinishDisbursementsCalculationJob

--- a/lib/tasks/calculate_disbursements.rake
+++ b/lib/tasks/calculate_disbursements.rake
@@ -1,0 +1,34 @@
+desc "Calculate commissions for all disbursements"
+task calculate_disbursements: :environment do
+  puts "========== STARTED CALCULATING DISBURSEMENTS =========="
+  starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+  calculated = 0
+  errors = []
+
+  begin
+    Disbursement.pending_or_processing.find_each do |disbursement|
+      FinishDisbursementCalculation.new.call(disbursement)
+      calculated += 1
+      print "."
+    end
+  rescue => e
+    print "F"
+    errors << {disbursement_id: disbursement.id, errors: e}
+  end
+
+  ending = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  elapsed = ending - starting
+
+  puts "\n========== FINISHED CALCULATING DISBURSEMENTS =========="
+  puts "\n-- SUMMARY --"
+  puts "Elapsed time: #{elapsed.round(2)} seconds"
+  puts "Total calculated disbursements: #{calculated}"
+
+  if errors.any?
+    puts "\n\n#{errors.count} errors:"
+    puts errors.join("\n")
+  else
+    puts "\n\nNo errors"
+  end
+end

--- a/lib/tasks/generate_report.rake
+++ b/lib/tasks/generate_report.rake
@@ -1,0 +1,33 @@
+desc "Generate disbursements report"
+task generate_report: :environment do
+  query = <<-SQL
+    SELECT
+      EXTRACT(YEAR FROM d.reference_date) AS year,
+      COUNT(d.id) AS disbursements_count,
+      SUM(d.total_amount_cents) AS amount_disbursed_in_cents,
+      SUM(d.total_commission_fee_cents) AS commission_fees_in_cents,
+      COUNT(d.monthly_fee_cents) FILTER (WHERE d.monthly_fee_cents IS NOT NULL) AS monthly_fees_count,
+      SUM(d.monthly_fee_cents) AS monthly_fees_in_cents
+    FROM disbursements d
+    WHERE d.status = 'calculated'
+    GROUP BY 1
+    ORDER BY 1
+  SQL
+
+  data = []
+
+  ActiveRecord::Base.connection_pool.with_connection do |connection|
+    data = connection.execute(query).to_a
+  end
+
+  puts "\n-- REPORT --"
+  data.each do |row|
+    puts "----------------"
+    puts "Year: #{row["year"].to_i}"
+    puts "Number of disbursements: #{row["disbursements_count"]}"
+    puts "Amount disbursed to merchants: #{Money.new(row["amount_disbursed_in_cents"])}"
+    puts "Amount of order fees: #{Money.new(row["commission_fees_in_cents"])}"
+    puts "Number of monthly fees charged: #{row["monthly_fees_count"]}"
+    puts "Amount of monthly fee charged: #{Money.new(row["monthly_fees_in_cents"])}"
+  end
+end

--- a/spec/jobs/finish_disbursements_calculation_job_spec.rb
+++ b/spec/jobs/finish_disbursements_calculation_job_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe FinishDisbursementsCalculationJob, type: :job do
+  it "calculates commissions for disbursements with today as reference date" do
+    disbursement1 = create(:disbursement, :daily, :processing, reference_date: Date.today)
+    disbursement2 = create(:disbursement, :weekly, :processing, reference_date: Date.today)
+    other_disbursement = create(:disbursement, :daily, :processing, reference_date: Date.yesterday)
+
+    described_class.new.perform
+
+    disbursement1.reload
+    disbursement2.reload
+    other_disbursement.reload
+    expect(disbursement1).to be_calculated
+    expect(disbursement2).to be_calculated
+    expect(other_disbursement).to be_processing
+  end
+end

--- a/spec/models/disbursement_spec.rb
+++ b/spec/models/disbursement_spec.rb
@@ -11,6 +11,40 @@ RSpec.describe Disbursement do
     end
   end
 
+  context "when retrieving disbursements by month" do
+    it "returns disbursements within the month" do
+      this_month = Date.today
+      disbursement = create(:disbursement, reference_date: this_month)
+      _other_disbursement = create(:disbursement, reference_date: this_month.next_month)
+
+      expect(Disbursement.by_month(this_month)).to contain_exactly(disbursement)
+    end
+  end
+
+  context "when retrieving disbursements by merchant" do
+    it "returns disbursements for the merchant" do
+      merchant = create(:merchant)
+      disbursement = create(:disbursement, merchant:)
+      _other_disbursement = create(:disbursement, merchant: create(:merchant))
+
+      expect(Disbursement.by_merchant(merchant)).to contain_exactly(disbursement)
+    end
+  end
+
+  context "when checking if disbursement is the first of the month" do
+    it "returns true if reference date is the first day of the month" do
+      disbursement = build(:disbursement, reference_date: "2024-02-01")
+
+      expect(disbursement).to be_first_of_the_month
+    end
+
+    it "returns false if reference date is not the first day of the month" do
+      disbursement = build(:disbursement, reference_date: "2024-02-02")
+
+      expect(disbursement).not_to be_first_of_the_month
+    end
+  end
+
   context "when updating totals from commission" do
     it "raises error if disbursement is already calculated" do
       disbursement = create(:disbursement, :calculated)

--- a/spec/use_cases/finish_disbursement_calculation_spec.rb
+++ b/spec/use_cases/finish_disbursement_calculation_spec.rb
@@ -1,0 +1,134 @@
+require "rails_helper"
+
+RSpec.describe ::FinishDisbursementCalculation do
+  context "when disbursement is the first of the month" do
+    it "changes disbursement status to 'calculated'" do
+      reference_date = Date.today.beginning_of_month
+
+      merchant = create(:merchant, minimum_monthly_fee: Money.from_amount(100))
+      _last_month_disbursement1 = create(:disbursement, :calculated,
+        merchant:, reference_date: reference_date.prev_month,
+        total_commission_fee: Money.from_amount(50))
+      _last_month_disbursement2 = create(:disbursement, :calculated,
+        merchant:, reference_date: reference_date.prev_month,
+        total_commission_fee: Money.from_amount(60))
+
+      disbursement = create(:disbursement, :processing, reference_date:, merchant:)
+
+      described_class.new.call(disbursement)
+
+      disbursement.reload
+      expect(disbursement).to be_calculated
+      expect(disbursement.calculated_at).to be_within(1.minute).of(Time.zone.now)
+    end
+
+    context "when past month commissions are greater than merchant's minimum monthly fee" do
+      it "does not calculate monthly fee" do
+        reference_date = Date.today.beginning_of_month
+
+        merchant = create(:merchant, minimum_monthly_fee: Money.from_amount(100))
+        _last_month_disbursement1 = create(:disbursement, :calculated,
+          merchant:, reference_date: reference_date.prev_month,
+          total_commission_fee: Money.from_amount(50))
+        _last_month_disbursement2 = create(:disbursement, :calculated,
+          merchant:, reference_date: reference_date.prev_month,
+          total_commission_fee: Money.from_amount(60))
+
+        disbursement = create(:disbursement, :processing, reference_date:, merchant:)
+
+        described_class.new.call(disbursement)
+
+        disbursement.reload
+        expect(disbursement.monthly_fee).to eq(Money.from_amount(0))
+      end
+    end
+
+    context "when past month commissions are equal to merchant's minimum monthly fee" do
+      it "does not calculate monthly fee" do
+        reference_date = Date.today.beginning_of_month
+
+        merchant = create(:merchant, minimum_monthly_fee: Money.from_amount(100))
+        _last_month_disbursement1 = create(:disbursement, :calculated,
+          merchant:, reference_date: reference_date.prev_month,
+          total_commission_fee: Money.from_amount(50))
+        _last_month_disbursement2 = create(:disbursement, :calculated,
+          merchant:, reference_date: reference_date.prev_month,
+          total_commission_fee: Money.from_amount(50))
+
+        disbursement = create(:disbursement, :processing, reference_date:, merchant:)
+
+        described_class.new.call(disbursement)
+
+        disbursement.reload
+        expect(disbursement.monthly_fee).to eq(Money.from_amount(0))
+      end
+    end
+
+    context "when past month commissions are less than merchant's minimum monthly fee" do
+      it "calculates monthly fee" do
+        reference_date = Date.today.beginning_of_month
+
+        merchant = create(:merchant, minimum_monthly_fee: Money.from_amount(100))
+        _last_month_disbursement1 = create(:disbursement, :calculated,
+          merchant:, reference_date: reference_date.prev_month,
+          total_commission_fee: Money.from_amount(20))
+        _last_month_disbursement2 = create(:disbursement, :calculated,
+          merchant:, reference_date: reference_date.prev_month,
+          total_commission_fee: Money.from_amount(35))
+        _not_calculated_disbursement = create(:disbursement, :processing,
+          merchant:, reference_date: reference_date.prev_month,
+          total_commission_fee: Money.from_amount(30))
+        _other_merchant_disbursement = create(:disbursement, :calculated,
+          total_commission_fee: Money.from_amount(100))
+
+        disbursement = create(:disbursement, :processing, reference_date:, merchant:)
+
+        described_class.new.call(disbursement)
+
+        disbursement.reload
+        expect(disbursement.monthly_fee).to eq(Money.from_amount(45))
+      end
+    end
+  end
+
+  context "when disbursement is not the first of the month" do
+    it "changes disbursement status to 'calculated'" do
+      reference_date = Date.today.beginning_of_month + 1.week
+
+      merchant = create(:merchant, minimum_monthly_fee: Money.from_amount(100))
+      _last_month_disbursement1 = create(:disbursement, :calculated,
+        merchant:, reference_date: reference_date.prev_month,
+        total_commission_fee: Money.from_amount(20))
+      _last_month_disbursement2 = create(:disbursement, :calculated,
+        merchant:, reference_date: reference_date.prev_month,
+        total_commission_fee: Money.from_amount(10))
+
+      disbursement = create(:disbursement, :processing, reference_date:, merchant:)
+
+      described_class.new.call(disbursement)
+
+      disbursement.reload
+      expect(disbursement).to be_calculated
+      expect(disbursement.calculated_at).to be_within(1.minute).of(Time.zone.now)
+    end
+
+    it "does not calculate monthly fee" do
+      reference_date = Date.today.beginning_of_month + 1.week
+
+      merchant = create(:merchant, minimum_monthly_fee: Money.from_amount(100))
+      _last_month_disbursement1 = create(:disbursement, :calculated,
+        merchant:, reference_date: reference_date.prev_month,
+        total_commission_fee: Money.from_amount(20))
+      _last_month_disbursement2 = create(:disbursement, :calculated,
+        merchant:, reference_date: reference_date.prev_month,
+        total_commission_fee: Money.from_amount(10))
+
+      disbursement = create(:disbursement, :processing, reference_date:, merchant:)
+
+      described_class.new.call(disbursement)
+
+      disbursement.reload
+      expect(disbursement.monthly_fee).to eq(Money.from_amount(0))
+    end
+  end
+end


### PR DESCRIPTION
Job and use cases to finish the disbursement commission calculation.
* The job gets all disbursements that should be disbursed on that day at 7:50PM (to make sure it will be done by 8PM) and calls that `FinishDisbursementCalculation` use case
* The use case:
  * sets the disbursement as `calculated`
  * calculates monthly fee based on previous month commissions (if its disbursement is in the first day of the month)

⚠️ If more than 1 disbursement is calculated on the 1st day of the month, the montly fee will be duplicated.

---

Along with this PR, I also included 2 rake tasks:
* To finish all disbursements calculation
* To print a report with disbursements info (needed for the readme)

---

> PS. This PR finishes the challenge implementation 🎉 